### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: python -m pip install build twine

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,10 @@
 # Required
 version: 2
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
+
 # Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-22.04

--- a/sammi/tests/test_validation.py
+++ b/sammi/tests/test_validation.py
@@ -1,10 +1,8 @@
 from pathlib import Path
-import tempfile
 import requests
 import requests_mock
 
 import pytest
-import yaml
 
 from sammi.validation import CDFValidator
 
@@ -22,7 +20,7 @@ def test_validate_raw_valid_cdf(validator: CDFValidator):
 
     result = validator.validate_raw(test_data_dir / "test_valid.cdf")
     assert type(result) == str
-    assert "Error" not in result
+    assert "The following variables are not ISTP-compliant" not in result
 
 
 def test_validate_raw_invalid_cdf(validator: CDFValidator):
@@ -31,7 +29,8 @@ def test_validate_raw_invalid_cdf(validator: CDFValidator):
 
     result = validator.validate_raw(test_data_dir / "test_invalid.cdf")
     assert type(result) == str
-    assert "Error" in result
+    assert "Global errors" in result
+    assert "The following variables are not ISTP-compliant" in result
 
 
 def test_validate_raw_no_internet(validator: CDFValidator):


### PR DESCRIPTION
Readthedocs was breaking because of: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

Upgrade Python Versions used in CI based on: https://devguide.python.org/versions/

SPDF updated the output formatting and wording of their API which broke our validation module. 