### PR TITLE
Fix encoding issues on Windows

### DIFF
--- a/sammi/cdf_attribute_manager.py
+++ b/sammi/cdf_attribute_manager.py
@@ -232,7 +232,7 @@ class CdfAttributeManager:
         assert Path(file_path).exists()
         # Load the Yaml file to Dict
         yaml_data = {}
-        with open(file_path, "r") as f:
+        with open(file_path, "rb") as f:
             yaml_data = yaml.safe_load(f)
         return yaml_data
 

--- a/sammi/tests/test_cdf_attribute_manager.py
+++ b/sammi/tests/test_cdf_attribute_manager.py
@@ -485,6 +485,9 @@ def test_get_variable_attributes(cdf_manager):
     assert imap_test_variable_1_false["NOT_IN_SCHEMA"] == "not_in_schema"
     assert imap_test_variable_1_false["VALIDMIN"] == 0
 
+    var_with_non_ascii_text = cdf_manager.get_variable_attributes("test_field_4")
+    assert var_with_non_ascii_text["CATDESC"] == "α-particles"
+
 
 def test_sw_templates(cdf_manager):
     """Test Global and Variable Attribute Templates"""

--- a/sammi/tests/test_data/imap_test_variable.yaml
+++ b/sammi/tests/test_data/imap_test_variable.yaml
@@ -39,3 +39,7 @@ test_field_3:
   DEPEND_1: depend_1_test_3
   LABL_PTR_1: labl_ptr_1
   REPRESENTATION_2: representation_2
+
+test_field_4:
+  <<: *default
+  CATDESC: α-particles


### PR DESCRIPTION
Opening files in text mode on Windows defaults to a non-utf-8 encoding. This can corrupt characters outside of the ASCII range.

Open YAML files as binary and let the yaml library handle decoding to avoid this default.