### PR TITLE
Function for adding data variable metadata

### DIFF
--- a/sammi/cdf_attribute_manager.py
+++ b/sammi/cdf_attribute_manager.py
@@ -535,8 +535,9 @@ class CdfAttributeManager:
 
         return output
 
-    def add_variable_attribute(self, variable_name: str, attribute_name: str,
-                               attribute_value: str) -> None:
+    def add_variable_attribute(
+        self, variable_name: str, attribute_name: str, attribute_value: str
+    ) -> None:
         """
         Add a single variable attribute to the variable attributes.
 

--- a/sammi/cdf_attribute_manager.py
+++ b/sammi/cdf_attribute_manager.py
@@ -535,7 +535,8 @@ class CdfAttributeManager:
 
         return output
 
-    def add_variable_attribute(self, attribute_name: str, attribute_value: str) -> None:
+    def add_variable_attribute(self, variable_name: str, attribute_name: str,
+                               attribute_value: str) -> None:
         """
         Add a single variable attribute to the variable attributes.
 
@@ -553,7 +554,9 @@ class CdfAttributeManager:
         attribute_value : str
             The value of the attribute to add.
         """
-        self._variable_attributes[attribute_name] = attribute_value
+        if variable_name not in self._variable_attributes:
+            self._variable_attributes[variable_name] = {}
+        self._variable_attributes[variable_name][attribute_name] = attribute_value
 
     def variable_attribute_template(self) -> dict:
         """

--- a/sammi/cdf_attribute_manager.py
+++ b/sammi/cdf_attribute_manager.py
@@ -535,6 +535,26 @@ class CdfAttributeManager:
 
         return output
 
+    def add_variable_attribute(self, attribute_name: str, attribute_value: str) -> None:
+        """
+        Add a single variable attribute to the variable attributes.
+
+        This is intended only for dynamic variable attributes which change per-file.
+        It is not intended to be used for static attributes, which
+        should all be included in the YAML files.
+
+        This will overwrite any existing value in attribute_name if it exists. The
+        attribute must be in the variable schema, or it will not be included as output.
+
+        Parameters
+        ----------
+        attribute_name : str
+            The name of the attribute to add.
+        attribute_value : str
+            The value of the attribute to add.
+        """
+        self._variable_attributes[attribute_name] = attribute_value
+
     def variable_attribute_template(self) -> dict:
         """
         Function to generate a template of required variable attributes

--- a/sammi/tests/test_cdf_attribute_manager.py
+++ b/sammi/tests/test_cdf_attribute_manager.py
@@ -488,11 +488,13 @@ def test_get_variable_attributes(cdf_manager):
     var_with_non_ascii_text = cdf_manager.get_variable_attributes("test_field_4")
     assert var_with_non_ascii_text["CATDESC"] == "α-particles"
 
+
 def test_add_variable_attribute(cdf_manager):
     """Test that add_variable_attribute correctly adds a variable attribute."""
     # Add a new variable with a single attribute
     cdf_manager.add_variable_attribute("Epoch", "CATDESC", "Default time")
     assert cdf_manager._variable_attributes["Epoch"]["CATDESC"] == "Default time"
+
 
 def test_add_variable_attribute_new_variable(cdf_manager):
     """Test that add_variable_attribute creates a new variable entry if it doesn't exist."""
@@ -500,11 +502,13 @@ def test_add_variable_attribute_new_variable(cdf_manager):
     assert "NewVar" in cdf_manager._variable_attributes
     assert cdf_manager._variable_attributes["NewVar"]["FIELDNAM"] == "New Variable"
 
+
 def test_add_variable_attribute_overwrites_existing(cdf_manager):
     """Test that add_variable_attribute overwrites an existing attribute value."""
     cdf_manager.add_variable_attribute("Epoch", "CATDESC", "Original")
     cdf_manager.add_variable_attribute("Epoch", "CATDESC", "Updated")
     assert cdf_manager._variable_attributes["Epoch"]["CATDESC"] == "Updated"
+
 
 def test_add_variable_attribute_multiple_attributes(cdf_manager):
     """Test that multiple attributes can be added to the same variable."""
@@ -512,6 +516,7 @@ def test_add_variable_attribute_multiple_attributes(cdf_manager):
     cdf_manager.add_variable_attribute("Epoch", "FIELDNAM", "Epoch")
     assert cdf_manager._variable_attributes["Epoch"]["CATDESC"] == "Default time"
     assert cdf_manager._variable_attributes["Epoch"]["FIELDNAM"] == "Epoch"
+
 
 def test_sw_templates(cdf_manager):
     """Test Global and Variable Attribute Templates"""

--- a/sammi/tests/test_cdf_attribute_manager.py
+++ b/sammi/tests/test_cdf_attribute_manager.py
@@ -488,6 +488,30 @@ def test_get_variable_attributes(cdf_manager):
     var_with_non_ascii_text = cdf_manager.get_variable_attributes("test_field_4")
     assert var_with_non_ascii_text["CATDESC"] == "α-particles"
 
+def test_add_variable_attribute(cdf_manager):
+    """Test that add_variable_attribute correctly adds a variable attribute."""
+    # Add a new variable with a single attribute
+    cdf_manager.add_variable_attribute("Epoch", "CATDESC", "Default time")
+    assert cdf_manager._variable_attributes["Epoch"]["CATDESC"] == "Default time"
+
+def test_add_variable_attribute_new_variable(cdf_manager):
+    """Test that add_variable_attribute creates a new variable entry if it doesn't exist."""
+    cdf_manager.add_variable_attribute("NewVar", "FIELDNAM", "New Variable")
+    assert "NewVar" in cdf_manager._variable_attributes
+    assert cdf_manager._variable_attributes["NewVar"]["FIELDNAM"] == "New Variable"
+
+def test_add_variable_attribute_overwrites_existing(cdf_manager):
+    """Test that add_variable_attribute overwrites an existing attribute value."""
+    cdf_manager.add_variable_attribute("Epoch", "CATDESC", "Original")
+    cdf_manager.add_variable_attribute("Epoch", "CATDESC", "Updated")
+    assert cdf_manager._variable_attributes["Epoch"]["CATDESC"] == "Updated"
+
+def test_add_variable_attribute_multiple_attributes(cdf_manager):
+    """Test that multiple attributes can be added to the same variable."""
+    cdf_manager.add_variable_attribute("Epoch", "CATDESC", "Default time")
+    cdf_manager.add_variable_attribute("Epoch", "FIELDNAM", "Epoch")
+    assert cdf_manager._variable_attributes["Epoch"]["CATDESC"] == "Default time"
+    assert cdf_manager._variable_attributes["Epoch"]["FIELDNAM"] == "Epoch"
 
 def test_sw_templates(cdf_manager):
     """Test Global and Variable Attribute Templates"""


### PR DESCRIPTION
I'm looking to expand SAMMI for use with NetCDFs for the TSIS-2 mission. One feature we need is to set metadata dynamically based on values in a database. To handle that, I added a function that allows the user to add data variable metadata so we can set attributes from the database that are not defined in the YAML (but are in the schema). 

Apart from whether you think this is right for SAMMI, there are a couple specific things I'm looking for feedback on:
- Right now the code allows the user to add new variables that are not defined in the YAML. For TSIS, we should only need some of the metadata fields to be set dynamically, not entire data variables. So we would likely define the variable with some of the metadata in the YAML and then set a metadata field or two with add_variable_attribute. This means we don't need the function to create a new variable if it does not exist, but I wasn't sure if that feature would be generally wanted. If not, I can remove that part of the function.
- I also allowed attributes to be overwritten. I don't think we'll need that, but was also not sure if that would be a wanted feature. I can restrict that if you don't want attributes to be overwritten.


I will be opening one or two more PRs with new schema files following the NetCDF CF metadata convention.