### PR TITLE
NetCDF CF Global and Data Variable Schema

### DIFF
--- a/sammi/data/default_global_acdd_attrs_schema.yaml
+++ b/sammi/data/default_global_acdd_attrs_schema.yaml
@@ -1,0 +1,427 @@
+# https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3#Global_Attributes
+
+# Highly Recommended
+title:
+    description: >
+        A short phrase or sentence describing the dataset. In many discovery systems, the title will be
+        displayed in the results list from a search, and therefore should be human readable and reasonable
+        to display in a list of such names. This attribute is also recommended by the NetCDF Users Guide
+        and the CF conventions.
+    default: null
+    required: false
+summary:
+    description: >
+        A paragraph describing the dataset, analogous to an abstract for a paper.
+    default: null
+    required: false
+keywords:
+    description: >
+        A comma-separated list of key words and/or phrases. Keywords may be common words or phrases,
+        terms from a controlled vocabulary (GCMD is often used), or URIs for terms from a controlled
+        vocabulary (see also "keywords_vocabulary" attribute).
+    default: null
+    required: false
+Conventions:
+    description: >
+        A comma-separated list of the conventions that are followed by the dataset. For files that follow
+        this version of ACDD, include the string 'ACDD-1.3'. (This attribute is described in the NetCDF
+        Users Guide.)
+    default: null
+    required: false
+
+# Recommended
+id:
+    description: >
+        An identifier for the data set, provided by and unique within its naming authority. The combination
+        of the "naming authority" and the "id" should be globally unique, but the id can be globally unique
+        by itself also. IDs can be URLs, URNs, DOIs, meaningful text strings, a local key, or any other
+        unique string of characters. The id should not include white space characters.
+    default: null
+    required: false
+naming_authority:
+    description: >
+        The organization that provides the initial id (see above) for the dataset. The naming authority
+        should be uniquely specified by this attribute. We recommend using reverse-DNS naming for the
+        naming authority; URIs are also acceptable. Example: 'edu.ucar.unidata'.
+    default: null
+    required: false
+history:
+    description: >
+        Provides an audit trail for modifications to the original data. This attribute is also in the
+        NetCDF Users Guide: 'This is a character array with a line for each invocation of a program that
+        has modified the dataset. Well-behaved generic netCDF applications should append a line containing:
+        date, time of day, user name, program name and command arguments.' To include a more complete
+        description you can append a reference to an ISO Lineage entity; see NOAA EDM ISO Lineage guidance.
+    default: null
+    required: false
+source:
+    description: >
+        The method of production of the original data. If it was model-generated, source should name the
+        model and its version. If it is observational, source should characterize it. This attribute is
+        defined in the CF Conventions. Examples: 'temperature from CTD #1234'; 'world model v.0.1'.
+    default: null
+    required: false
+processing_level:
+    description: >
+        A textual description of the processing (or quality control) level of the data.
+    default: null
+    required: false
+comment:
+    description: >
+        Miscellaneous information about the data, not captured elsewhere. This attribute is defined in
+        the CF Conventions.
+    default: null
+    required: false
+acknowledgement:
+    description: >
+        A place to acknowledge various types of support for the project that produced this data.
+    default: null
+    required: false
+license:
+    description: >
+        Provide the URL to a standard or specific license, enter "Freely Distributed" or "None", or
+        describe any restrictions to data access and distribution in free text.
+    default: null
+    required: false
+standard_name_vocabulary:
+    description: >
+        The name and version of the controlled vocabulary from which variable standard names are taken.
+        (Values for any standard_name attribute must come from the CF Standard Names vocabulary for the
+        data file or product to comply with CF.) Example: 'CF Standard Name Table v27'.
+    default: null
+    required: false
+date_created:
+    description: >
+        The date on which this version of the data was created. (Modification of values implies a new
+        version, hence this would be assigned the date of the most recent values modification.) Metadata
+        changes are not considered when assigning the date_created. The ISO 8601:2004 extended date format
+        is recommended, as described in the Attribute Content Guidance section.
+    default: null
+    required: false
+creator_name:
+    description: >
+        The name of the person (or other creator type specified by the creator_type attribute) principally
+        responsible for creating this data.
+    default: null
+    required: false
+creator_email:
+    description: >
+        The email address of the person (or other creator type specified by the creator_type attribute)
+        principally responsible for creating this data.
+    default: null
+    required: false
+creator_url:
+    description: >
+        The URL of the person (or other creator type specified by the creator_type attribute) principally
+        responsible for creating this data.
+    default: null
+    required: false
+institution:
+    description: >
+        The name of the institution principally responsible for originating this data. This attribute is
+        recommended by the CF convention.
+    default: null
+    required: false
+project:
+    description: >
+        The name of the project(s) principally responsible for originating this data. Multiple projects
+        can be separated by commas, as described under Attribute Content Guidelines. Examples:
+        'PATMOS-X', 'Extended Continental Shelf Project'.
+    default: null
+    required: false
+publisher_name:
+    description: >
+        The name of the person (or other entity specified by the publisher_type attribute) responsible
+        for publishing the data file or product to users, with its current metadata and format.
+    default: null
+    required: false
+publisher_email:
+    description: >
+        The email address of the person (or other entity specified by the publisher_type attribute)
+        responsible for publishing the data file or product to users, with its current metadata and format.
+    default: null
+    required: false
+publisher_url:
+    description: >
+        The URL of the person (or other entity specified by the publisher_type attribute) responsible
+        for publishing the data file or product to users, with its current metadata and format.
+    default: null
+    required: false
+geospatial_bounds:
+    description: >
+        Describes the data's 2D or 3D geospatial extent in OGC's Well-Known Text (WKT) Geometry format
+        (reference the OGC Simple Feature Access (SFA) specification). The meaning and order of values
+        for each point's coordinates depends on the coordinate reference system (CRS). The ACDD default
+        is 2D geometry in the EPSG:4326 coordinate reference system. The default may be overridden with
+        geospatial_bounds_crs and geospatial_bounds_vertical_crs (see those attributes). EPSG:4326
+        coordinate values are latitude (decimal degrees_north) and longitude (decimal degrees_east), in
+        that order. Longitude values in the default case are limited to the [-180, 180) range. Example:
+        'POLYGON ((40.26 -111.29, 41.26 -111.29, 41.26 -110.29, 40.26 -110.29, 40.26 -111.29))'.
+    default: null
+    required: false
+geospatial_bounds_crs:
+    description: >
+        The coordinate reference system (CRS) of the point coordinates in the geospatial_bounds attribute.
+        This CRS may be 2-dimensional or 3-dimensional, but together with geospatial_bounds_vertical_crs,
+        if that attribute is supplied, must match the dimensionality, order, and meaning of point coordinate
+        values in the geospatial_bounds attribute. If geospatial_bounds_vertical_crs is also present then
+        this attribute must only specify a 2D CRS. EPSG CRSs are strongly recommended. If this attribute
+        is not specified, the CRS is assumed to be EPSG:4326. Examples: 'EPSG:4979' (the 3D WGS84 CRS),
+        'EPSG:4047'.
+    default: null
+    required: false
+geospatial_bounds_vertical_crs:
+    description: >
+        The vertical coordinate reference system (CRS) for the Z axis of the point coordinates in the
+        geospatial_bounds attribute. This attribute cannot be used if the CRS in geospatial_bounds_crs is
+        3-dimensional; to use this attribute, geospatial_bounds_crs must exist and specify a 2D CRS. EPSG
+        CRSs are strongly recommended. There is no default for this attribute when not specified. Examples:
+        'EPSG:5829' (instantaneous height above sea level), "EPSG:5831" (instantaneous depth below sea
+        level), or 'EPSG:5703' (NAVD88 height).
+    default: null
+    required: false
+geospatial_lat_min:
+    description: >
+        Describes a simple lower latitude limit; may be part of a 2- or 3-dimensional bounding region.
+        Geospatial_lat_min specifies the southernmost latitude covered by the dataset.
+    default: null
+    required: false
+geospatial_lat_max:
+    description: >
+        Describes a simple upper latitude limit; may be part of a 2- or 3-dimensional bounding region.
+        Geospatial_lat_max specifies the northernmost latitude covered by the dataset.
+    default: null
+    required: false
+geospatial_lon_min:
+    description: >
+        Describes a simple longitude limit; may be part of a 2- or 3-dimensional bounding region.
+        geospatial_lon_min specifies the westernmost longitude covered by the dataset. See also
+        geospatial_lon_max.
+    default: null
+    required: false
+geospatial_lon_max:
+    description: >
+        Describes a simple longitude limit; may be part of a 2- or 3-dimensional bounding region.
+        geospatial_lon_max specifies the easternmost longitude covered by the dataset. Cases where
+        geospatial_lon_min is greater than geospatial_lon_max indicate the bounding box extends from
+        geospatial_lon_max, through the longitude range discontinuity meridian (either the antimeridian
+        for -180:180 values, or Prime Meridian for 0:360 values), to geospatial_lon_min; for example,
+        geospatial_lon_min=170 and geospatial_lon_max=-175 incorporates 15 degrees of longitude (ranges
+        170 to 180 and -180 to -175).
+    default: null
+    required: false
+geospatial_vertical_min:
+    description: >
+        Describes the numerically smaller vertical limit; may be part of a 2- or 3-dimensional bounding
+        region. See geospatial_vertical_positive and geospatial_vertical_units.
+    default: null
+    required: false
+geospatial_vertical_max:
+    description: >
+        Describes the numerically larger vertical limit; may be part of a 2- or 3-dimensional bounding
+        region. See geospatial_vertical_positive and geospatial_vertical_units.
+    default: null
+    required: false
+geospatial_vertical_positive:
+    description: >
+        One of 'up' or 'down'. If up, vertical values are interpreted as 'altitude', with negative values
+        corresponding to below the reference datum (e.g., under water). If down, vertical values are
+        interpreted as 'depth', positive values correspond to below the reference datum. Note that if
+        geospatial_vertical_positive is down ('depth' orientation), the geospatial_vertical_min attribute
+        specifies the data's vertical location furthest from the earth's center, and the
+        geospatial_vertical_max attribute specifies the location closest to the earth's center.
+    default: null
+    required: false
+time_coverage_start:
+    description: >
+        Describes the time of the first data point in the data set. Use the ISO 8601:2004 date format,
+        preferably the extended format as recommended in the Attribute Content Guidance section.
+    default: null
+    required: false
+time_coverage_end:
+    description: >
+        Describes the time of the last data point in the data set. Use ISO 8601:2004 date format,
+        preferably the extended format as recommended in the Attribute Content Guidance section.
+    default: null
+    required: false
+time_coverage_duration:
+    description: >
+        Describes the duration of the data set. Use ISO 8601:2004 duration format, preferably the
+        extended format as recommended in the Attribute Content Guidance section.
+    default: null
+    required: false
+time_coverage_resolution:
+    description: >
+        Describes the targeted time period between each value in the data set. Use ISO 8601:2004 duration
+        format, preferably the extended format as recommended in the Attribute Content Guidance section.
+    default: null
+    required: false
+
+# Suggested
+creator_type:
+    description: >
+        Specifies type of creator with one of the following: 'person', 'group', 'institution', or
+        'position'. If this attribute is not specified, the creator is assumed to be a person.
+    default: null
+    required: false
+creator_institution:
+    description: >
+        The institution of the creator; should uniquely identify the creator's institution. This
+        attribute's value should be specified even if it matches the value of publisher_institution,
+        or if creator_type is institution.
+    default: null
+    required: false
+publisher_type:
+    description: >
+        Specifies type of publisher with one of the following: 'person', 'group', 'institution', or
+        'position'. If this attribute is not specified, the publisher is assumed to be a person.
+    default: null
+    required: false
+publisher_institution:
+    description: >
+        The institution that presented the data file or equivalent product to users; should uniquely
+        identify the institution. If publisher_type is institution, this should have the same value
+        as publisher_name.
+    default: null
+    required: false
+program:
+    description: >
+        The overarching program(s) of which the dataset is a part. A program consists of a set (or
+        portfolio) of related and possibly interdependent projects that meet an overarching objective.
+        Examples: 'GHRSST', 'NOAA CDR', 'NASA EOS', 'JPSS', 'GOES-R'.
+    default: null
+    required: false
+contributor_name:
+    description: >
+        The name of any individuals, projects, or institutions that contributed to the creation of this
+        data. May be presented as free text, or in a structured format compatible with conversion to
+        ncML (e.g., insensitive to changes in whitespace, including end-of-line characters).
+    default: null
+    required: false
+contributor_role:
+    description: >
+        The role of any individuals, projects, or institutions that contributed to the creation of this
+        data. May be presented as free text, or in a structured format compatible with conversion to
+        ncML (e.g., insensitive to changes in whitespace, including end-of-line characters). Multiple
+        roles should be presented in the same order and number as the names in contributor_names.
+    default: null
+    required: false
+geospatial_lat_units:
+    description: >
+        Units for the latitude axis described in "geospatial_lat_min" and "geospatial_lat_max" attributes.
+        These are presumed to be "degree_north"; other options from udunits may be specified instead.
+    default: null
+    required: false
+geospatial_lat_resolution:
+    description: >
+        Information about the targeted spacing of points in latitude. Recommend describing resolution as
+        a number value followed by the units. Examples: '100 meters', '0.1 degree'
+    default: null
+    required: false
+geospatial_lon_units:
+    description: >
+        Units for the longitude axis described in "geospatial_lon_min" and "geospatial_lon_max" attributes.
+        These are presumed to be "degree_east"; other options from udunits may be specified instead.
+    default: null
+    required: false
+geospatial_lon_resolution:
+    description: >
+        Information about the targeted spacing of points in longitude. Recommend describing resolution as
+        a number value followed by units. Examples: '100 meters', '0.1 degree'
+    default: null
+    required: false
+geospatial_vertical_units:
+    description: >
+        Units for the vertical axis described in "geospatial_vertical_min" and "geospatial_vertical_max"
+        attributes. The default is EPSG:4979 (height above the ellipsoid, in meters); other vertical
+        coordinate reference systems may be specified. Note that the common oceanographic practice of
+        using pressure for a vertical coordinate, while not strictly a depth, can be specified using the
+        unit bar. Examples: 'EPSG:5829' (instantaneous height above sea level), 'EPSG:5831'
+        (instantaneous depth below sea level).
+    default: null
+    required: false
+geospatial_vertical_resolution:
+    description: >
+        Information about the targeted vertical spacing of points. Example: '25 meters'
+    default: null
+    required: false
+date_modified:
+    description: >
+        The date on which the data was last modified. Note that this applies just to the data, not the
+        metadata. The ISO 8601:2004 extended date format is recommended, as described in the Attributes
+        Content Guidance section.
+    default: null
+    required: false
+date_issued:
+    description: >
+        The date on which this data (including all modifications) was formally issued (i.e., made
+        available to a wider audience). Note that these apply just to the data, not the metadata. The
+        ISO 8601:2004 extended date format is recommended, as described in the Attributes Content
+        Guidance section.
+    default: null
+    required: false
+date_metadata_modified:
+    description: >
+        The date on which the metadata was last modified. The ISO 8601:2004 extended date format is
+        recommended, as described in the Attributes Content Guidance section.
+    default: null
+    required: false
+product_version:
+    description: >
+        Version identifier of the data file or product as assigned by the data creator. For example,
+        a new algorithm or methodology could result in a new product_version.
+    default: null
+    required: false
+keywords_vocabulary:
+    description: >
+        If you are using a controlled vocabulary for the words/phrases in your "keywords" attribute,
+        this is the unique name or identifier of the vocabulary from which keywords are taken. If more
+        than one keyword vocabulary is used, each may be presented with a prefix and a following comma,
+        so that keywords may optionally be prefixed with the controlled vocabulary key. Example:
+        'GCMD:GCMD Keywords, CF:NetCDF COARDS Climate and Forecast Standard Names'.
+    default: null
+    required: false
+platform:
+    description: >
+        Name of the platform(s) that supported the sensor data used to create this data set or product.
+        Platforms can be of any type, including satellite, ship, station, aircraft or other. Indicate
+        controlled vocabulary used in platform_vocabulary.
+    default: null
+    required: false
+platform_vocabulary:
+    description: >
+        Controlled vocabulary for the names used in the "platform" attribute.
+    default: null
+    required: false
+instrument:
+    description: >
+        Name of the contributing instrument(s) or sensor(s) used to create this data set or product.
+        Indicate controlled vocabulary used in instrument_vocabulary.
+    default: null
+    required: false
+instrument_vocabulary:
+    description: >
+        Controlled vocabulary for the names used in the "instrument" attribute.
+    default: null
+    required: false
+cdm_data_type:
+    description: >
+        The data type, as derived from Unidata's Common Data Model Scientific Data types and understood
+        by THREDDS. (This is a THREDDS "dataType", and is different from the CF NetCDF attribute
+        'featureType', which indicates a Discrete Sampling Geometry file in CF.)
+    default: null
+    required: false
+metadata_link:
+    description: >
+        A URL that gives the location of more complete metadata. A persistent URL is recommended for
+        this attribute.
+    default: null
+    required: false
+references:
+    description: >
+        Published or web-based references that describe the data or methods used to produce it.
+        Recommend URIs (such as a URL or DOI) for papers or other references. This attribute is defined
+        in the CF conventions.
+    default: null
+    required: false
+

--- a/sammi/data/default_global_cf_attrs_schema.yaml
+++ b/sammi/data/default_global_cf_attrs_schema.yaml
@@ -1,46 +1,46 @@
 # https://cfconventions.org/Data/cf-conventions/cf-conventions-1.13/cf-conventions.html#attribute-appendix
 comment:
-  description: >
-    Miscellaneous information about the data or methods used to produce it.
-  default: null
-  required: false
+    description: >
+        Miscellaneous information about the data or methods used to produce it.
+    default: null
+    required: false
 Conventions:
-  description: >
-    Name of the conventions followed by the dataset.
-  default: null
-  required: true
+    description: >
+        Name of the conventions followed by the dataset.
+    default: null
+    required: true
 external_variables:
-  description: >
-    Identifies variables which are named by cell_measures attributes in the file but which are not present in the file.
-  default: null
-  required: false
+    description: >
+        Identifies variables which are named by cell_measures attributes in the file but which are not present in the file.
+    default: null
+    required: false
 featureType:
     description: >
         Specifies the type of discrete sampling geometry to which the data in the scope of this attribute belongs, and implies that all data variables in the scope of this attribute contain collections of features of that type.
     default: null
     required: false
 history:
-  description: >
-    List of the applications that have modified the original data.
-  default: null
-  required: false
+    description: >
+        List of the applications that have modified the original data.
+    default: null
+    required: false
 institution:
     description: >
-      Where the original data was produced.
+        Where the original data was produced.
     default: null
     required: false
 references:
     description: >
-      References that describe the data or methods used to produce it.
+        References that describe the data or methods used to produce it.
     default: null
     required: false
 source:
-  description: >
-    Method of production of the original data.
-  default: null
-  required: true
+    description: >
+        Method of production of the original data.
+    default: null
+    required: true
 title:
     description: >
-      Short description of the file contents.
+        Short description of the file contents.
     default: null
     required: false

--- a/sammi/data/default_global_cf_attrs_schema.yaml
+++ b/sammi/data/default_global_cf_attrs_schema.yaml
@@ -1,0 +1,241 @@
+# Schema is based on CF conventions as defined by NASA GES DISC Archive's
+# Data and Metadata Recommendations to Data providers document:
+# https://docserver.gesdisc.eosdis.nasa.gov/public/project/DataPub/GES_DISC_metadata_and_data_formats.pdf
+
+# Collection Level global metadata
+ShortName:
+  description: >
+    mnemonic or acronym of the data product name
+  default: null
+  required: true
+LongName:
+    description: >
+        a descriptive product name
+    default: null
+    required: true
+VersionID:
+  description: >
+    collection version of the data product
+  default: null
+  required: true
+Format:
+  description: >
+    file format of the data file
+  default: null
+  required: true
+ProcessingLevel:
+  description: >
+    The processing Level ( e.g., Level 1, 1B, 2, 2A, 2G, 3, 4)
+  default: null
+  required: true
+IdentifierProductDOIAuthority:
+  description: >
+    https://doi.org/ - product DOI authority
+  default: null
+  required: true
+IdentifierProductDOI:
+  description: >
+    10.5067/xxxxxx - product DOI number
+  default: null
+  required: true
+Conventions:
+  description: >
+    This should be an attribute with the value, e.g., “CF-1.n,” where n=0, 1, 2, 3, ...
+  default: null
+  required: true
+source:
+  description: >
+    Platforms/Instruments and any other factors related to the origin of the data product or products (if multi-sensor merged)
+  default: null
+  required: true
+DataSetQuality:
+    description: >
+       Overall assessment of quality of data, including relevant articles. Short summary is preferred.
+    default: null
+    required: true
+MapProjection:
+    description: >
+        Applies to gridded data. Useful for application data tools, such as ArcGIS
+    default: null
+    required: false
+ValidationData:
+    description: >
+        Description of or reference on how the data were validated
+    default: null
+    required: false
+history:
+    description: >
+        An audit trail for modifications to the original data. Well-behaved generic netCDF filters automatically append their names and the parameters with which they were invoked to the global history attribute of an input netCDF file. We recommend that each line begins with a timestamp indicating the date and time of day that the program was executed.
+    default: null
+    required: false
+references:
+    description: >
+      Published or Web-based references that describe the data or methods used to produce the data, e.g.,
+      Algorithm Theoretical Basis Document
+      (ATBD) for the algorithm
+    default: null
+    required: false
+ContactPersonName:
+    description: >
+        Name of the responsible person
+    default: null
+    required: false
+ContactPersonRole:
+    description: >
+        Role of the responsible person
+    default: null
+    required: false
+ContactPersonEmail:
+    description: >
+        electronicMailAddress of the responsible person
+    default: null
+    required: false
+ContactPersonAddress:
+    description: >
+        Location of the responsible person or organization
+    default: null
+    required: false
+RelatedURL:
+    description: >
+        Information about online sources related to the data
+    default: null
+    required: false
+title:
+    description: >
+      A succinct description of the data set
+      (similar to or same as LongName)
+    default: null
+    required: false
+institution:
+    description: >
+      Where the data were produced
+    default: null
+    required: false
+ProjectAbstract:
+    description: >
+      A brief summary of the project from which the data originated
+    default: null
+    required: false
+DataSetLanguage:
+    description: >
+      Language used within the data set, LanguageCode=ISO 639
+      default=English
+    default: null
+    required: false
+ProductParameters:
+    description: >
+      Keywords describing the data set
+    default: null
+    required: false
+Keyword:
+    description: >
+      Commonly-use word(s) or phrase(s), e.g., Deep Blue Algorithm
+    default: null
+    required: false
+ProcessingCenter:
+    description: >
+      Organization from which the data set can be obtained
+    default: null
+    required: false
+InputDataProducts:
+    description: >
+      Input data to the product of interest
+    default: null
+    required: false
+InputDataProductVersion:
+    description: >
+      Input data version
+    default: null
+    required: false
+DataProgress:
+    description: >
+      Status of data set
+    default: null
+    required: false
+TemporalRange:
+    description: >
+      Time period covered by the data set
+    default: null
+    required: false
+SpatialCoverage:
+    description: >
+      Geographic domain of the data set
+    default: null
+    required: false
+DataResolution:
+    description: >
+      Information about spatial resolution
+    default: null
+    required: false
+
+# Granule Level global metadata
+GranuleID:
+  description: >
+    name of the data granule (most commonly filename for single-file granules)
+  default: null
+  required: true
+RangeBeginningDate:
+    description: >
+        start date of the data in the file (format YYYY-MM-DD)
+    default: null
+    required: true
+RangeBeginningTime:
+    description: >
+        start time UTC of the data (format hh:mm:ss.ssssss)
+    default: null
+    required: true
+RangeEndingDate:
+    description: >
+        end date of the data in the file (format YYYY-MM-DD)
+    default: null
+    required: true
+RangeEndingTime:
+    description: >
+        end time UTC of the data (format hh:mm:ss.ssssss)
+    default: null
+    required: true
+ProductionDateTime:
+  description: >
+    the date and time that the file is generated (format YYYY-MM-DDT hh:mm:ss.ssssssZ, e.g., 2013-06-04T12:43:17.896000Z)
+  default: null
+  required: true
+ObservationArea:
+    description: >
+      Spatial coverage of the data (global or name of a geographic region)
+    default: null
+    required: false
+InputOriginalFile:
+    description: >
+      Input data files used to generate the file
+    default: null
+    required: false
+ProductGenerationAlgorithm:
+    description: >
+      The algorithm software used to produce the granule
+    default: null
+    required: false
+ProductGenerationAlgorithmVersion:
+    description: >
+      The version of algorithm that generates the product
+    default: null
+    required: false
+OriginalFileVersion:
+    description: >
+      Original File version
+    default: null
+    required: false
+OriginalFileProcessingCenter:
+    description: >
+      The data center or project where the product is generated
+    default: null
+    required: false
+SpatialCompletenessDefinition:
+    description: >
+      Definition of a measure of data quality: i.e. the ratio of grid elements containing valid values to total number of grid elements
+    default: null
+    required: false
+SpatialCompletenessRatio:
+    description: >
+      The data quality information: value for the previous metadata
+    default: null
+    required: false

--- a/sammi/data/default_global_cf_attrs_schema.yaml
+++ b/sammi/data/default_global_cf_attrs_schema.yaml
@@ -1,254 +1,46 @@
-# Schema is based on CF conventions as defined by NASA GES DISC Archive's
-# Data and Metadata Recommendations to Data providers document:
-# https://docserver.gesdisc.eosdis.nasa.gov/public/project/DataPub/GES_DISC_metadata_and_data_formats.pdf
-
-# Collection Level global metadata
-ShortName:
+# https://cfconventions.org/Data/cf-conventions/cf-conventions-1.13/cf-conventions.html#attribute-appendix
+comment:
   description: >
-    mnemonic or acronym of the data product name
+    Miscellaneous information about the data or methods used to produce it.
   default: null
-  required: true
-LongName:
-    description: >
-        a descriptive product name
-    default: null
-    required: true
-VersionID:
-  description: >
-    collection version of the data product
-  default: null
-  required: true
-Format:
-  description: >
-    file format of the data file
-  default: null
-  required: true
-ProcessingLevel:
-  description: >
-    The processing Level ( e.g., Level 1, 1B, 2, 2A, 2G, 3, 4)
-  default: null
-  required: true
-IdentifierProductDOIAuthority:
-  description: >
-    https://doi.org/ - product DOI authority
-  default: null
-  required: true
-IdentifierProductDOI:
-  description: >
-    10.5067/xxxxxx - product DOI number
-  default: null
-  required: true
-# also an attribute convention for data discovery (ACDD) global metadata
+  required: false
 Conventions:
   description: >
-    This should be an attribute with the value, e.g., “CF-1.n,” where n=0, 1, 2, 3, ...
+    Name of the conventions followed by the dataset.
   default: null
   required: true
-source:
+external_variables:
   description: >
-    Platforms/Instruments and any other factors related to the origin of the data product or products (if multi-sensor merged)
+    Identifies variables which are named by cell_measures attributes in the file but which are not present in the file.
   default: null
-  required: true
-DataSetQuality:
+  required: false
+featureType:
     description: >
-       Overall assessment of quality of data, including relevant articles. Short summary is preferred.
-    default: null
-    required: true
-MapProjection:
-    description: >
-        Applies to gridded data. Useful for application data tools, such as ArcGIS
-    default: null
-    required: false
-ValidationData:
-    description: >
-        Description of or reference on how the data were validated
+        Specifies the type of discrete sampling geometry to which the data in the scope of this attribute belongs, and implies that all data variables in the scope of this attribute contain collections of features of that type.
     default: null
     required: false
 history:
+  description: >
+    List of the applications that have modified the original data.
+  default: null
+  required: false
+institution:
     description: >
-        An audit trail for modifications to the original data. Well-behaved generic netCDF filters automatically append their names and the parameters with which they were invoked to the global history attribute of an input netCDF file. We recommend that each line begins with a timestamp indicating the date and time of day that the program was executed.
+      Where the original data was produced.
     default: null
     required: false
 references:
     description: >
-      Published or Web-based references that describe the data or methods used to produce the data, e.g.,
-      Algorithm Theoretical Basis Document
-      (ATBD) for the algorithm
+      References that describe the data or methods used to produce it.
     default: null
     required: false
-ContactPersonName:
-    description: >
-        Name of the responsible person
-    default: null
-    required: false
-ContactPersonRole:
-    description: >
-        Role of the responsible person
-    default: null
-    required: false
-ContactPersonEmail:
-    description: >
-        electronicMailAddress of the responsible person
-    default: null
-    required: false
-ContactPersonAddress:
-    description: >
-        Location of the responsible person or organization
-    default: null
-    required: false
-RelatedURL:
-    description: >
-        Information about online sources related to the data
-    default: null
-    required: false
-#also an attribute convention for data discovery (ACDD) global metadata
+source:
+  description: >
+    Method of production of the original data.
+  default: null
+  required: true
 title:
     description: >
-      A succinct description of the data set
-      (similar to or same as LongName)
+      Short description of the file contents.
     default: null
     required: false
-institution:
-    description: >
-      Where the data were produced
-    default: null
-    required: false
-ProjectAbstract:
-    description: >
-      A brief summary of the project from which the data originated
-    default: null
-    required: false
-DataSetLanguage:
-    description: >
-      Language used within the data set, LanguageCode=ISO 639
-      default=English
-    default: null
-    required: false
-ProductParameters:
-    description: >
-      Keywords describing the data set
-    default: null
-    required: false
-# GES DISC optional attribute (singular keyword vs plural keywords for data discovery)
-Keyword:
-    description: >
-      Commonly-use word(s) or phrase(s), e.g., Deep Blue Algorithm
-    default: null
-    required: false
-# Attribute convention for data discovery (ACDD) global metadata
-Keywords:
-    description: >
-      A comma-separated list of key words and/or phrases. Keywords may be common words or phrases, terms from a controlled vocabulary (GCMD is often used), or URIs for terms from a controlled vocabulary (see also "keywords_vocabulary" attribute).
-    default: null
-    required: false
-ProcessingCenter:
-    description: >
-      Organization from which the data set can be obtained
-    default: null
-    required: false
-InputDataProducts:
-    description: >
-      Input data to the product of interest
-    default: null
-    required: false
-InputDataProductVersion:
-    description: >
-      Input data version
-    default: null
-    required: false
-DataProgress:
-    description: >
-      Status of data set
-    default: null
-    required: false
-TemporalRange:
-    description: >
-      Time period covered by the data set
-    default: null
-    required: false
-SpatialCoverage:
-    description: >
-      Geographic domain of the data set
-    default: null
-    required: false
-DataResolution:
-    description: >
-      Information about spatial resolution
-    default: null
-    required: false
-
-
-
-# Granule Level global metadata
-GranuleID:
-  description: >
-    name of the data granule (most commonly filename for single-file granules)
-  default: null
-  required: true
-RangeBeginningDate:
-    description: >
-        start date of the data in the file (format YYYY-MM-DD)
-    default: null
-    required: true
-RangeBeginningTime:
-    description: >
-        start time UTC of the data (format hh:mm:ss.ssssss)
-    default: null
-    required: true
-RangeEndingDate:
-    description: >
-        end date of the data in the file (format YYYY-MM-DD)
-    default: null
-    required: true
-RangeEndingTime:
-    description: >
-        end time UTC of the data (format hh:mm:ss.ssssss)
-    default: null
-    required: true
-ProductionDateTime:
-  description: >
-    the date and time that the file is generated (format YYYY-MM-DDT hh:mm:ss.ssssssZ, e.g., 2013-06-04T12:43:17.896000Z)
-  default: null
-  required: true
-ObservationArea:
-    description: >
-      Spatial coverage of the data (global or name of a geographic region)
-    default: null
-    required: false
-InputOriginalFile:
-    description: >
-      Input data files used to generate the file
-    default: null
-    required: false
-ProductGenerationAlgorithm:
-    description: >
-      The algorithm software used to produce the granule
-    default: null
-    required: false
-ProductGenerationAlgorithmVersion:
-    description: >
-      The version of algorithm that generates the product
-    default: null
-    required: false
-OriginalFileVersion:
-    description: >
-      Original File version
-    default: null
-    required: false
-OriginalFileProcessingCenter:
-    description: >
-      The data center or project where the product is generated
-    default: null
-    required: false
-SpatialCompletenessDefinition:
-    description: >
-      Definition of a measure of data quality: i.e. the ratio of grid elements containing valid values to total number of grid elements
-    default: null
-    required: false
-SpatialCompletenessRatio:
-    description: >
-      The data quality information: value for the previous metadata
-    default: null
-    required: false
-
-# Attribute Convention for Data Discovery (ACDD) global metadata

--- a/sammi/data/default_global_cf_attrs_schema.yaml
+++ b/sammi/data/default_global_cf_attrs_schema.yaml
@@ -38,6 +38,7 @@ IdentifierProductDOI:
     10.5067/xxxxxx - product DOI number
   default: null
   required: true
+# also an attribute convention for data discovery (ACDD) global metadata
 Conventions:
   description: >
     This should be an attribute with the value, e.g., “CF-1.n,” where n=0, 1, 2, 3, ...
@@ -100,6 +101,7 @@ RelatedURL:
         Information about online sources related to the data
     default: null
     required: false
+#also an attribute convention for data discovery (ACDD) global metadata
 title:
     description: >
       A succinct description of the data set
@@ -127,9 +129,16 @@ ProductParameters:
       Keywords describing the data set
     default: null
     required: false
+# GES DISC optional attribute (singular keyword vs plural keywords for data discovery)
 Keyword:
     description: >
       Commonly-use word(s) or phrase(s), e.g., Deep Blue Algorithm
+    default: null
+    required: false
+# Attribute convention for data discovery (ACDD) global metadata
+Keywords:
+    description: >
+      A comma-separated list of key words and/or phrases. Keywords may be common words or phrases, terms from a controlled vocabulary (GCMD is often used), or URIs for terms from a controlled vocabulary (see also "keywords_vocabulary" attribute).
     default: null
     required: false
 ProcessingCenter:
@@ -167,6 +176,8 @@ DataResolution:
       Information about spatial resolution
     default: null
     required: false
+
+
 
 # Granule Level global metadata
 GranuleID:
@@ -239,3 +250,5 @@ SpatialCompletenessRatio:
       The data quality information: value for the previous metadata
     default: null
     required: false
+
+# Attribute Convention for Data Discovery (ACDD) global metadata

--- a/sammi/data/default_global_gesdisc_attrs_schema.yaml
+++ b/sammi/data/default_global_gesdisc_attrs_schema.yaml
@@ -1,0 +1,254 @@
+# Schema is based on CF conventions as defined by NASA GES DISC Archive's
+# Data and Metadata Recommendations to Data providers document:
+# https://docserver.gesdisc.eosdis.nasa.gov/public/project/DataPub/GES_DISC_metadata_and_data_formats.pdf
+
+# Collection Level global metadata
+ShortName:
+  description: >
+    mnemonic or acronym of the data product name
+  default: null
+  required: true
+LongName:
+    description: >
+        a descriptive product name
+    default: null
+    required: true
+VersionID:
+  description: >
+    collection version of the data product
+  default: null
+  required: true
+Format:
+  description: >
+    file format of the data file
+  default: null
+  required: true
+ProcessingLevel:
+  description: >
+    The processing Level ( e.g., Level 1, 1B, 2, 2A, 2G, 3, 4)
+  default: null
+  required: true
+IdentifierProductDOIAuthority:
+  description: >
+    https://doi.org/ - product DOI authority
+  default: null
+  required: true
+IdentifierProductDOI:
+  description: >
+    10.5067/xxxxxx - product DOI number
+  default: null
+  required: true
+# also an attribute convention for data discovery (ACDD) global metadata
+Conventions:
+  description: >
+    This should be an attribute with the value, e.g., “CF-1.n,” where n=0, 1, 2, 3, ...
+  default: null
+  required: true
+source:
+  description: >
+    Platforms/Instruments and any other factors related to the origin of the data product or products (if multi-sensor merged)
+  default: null
+  required: true
+DataSetQuality:
+    description: >
+       Overall assessment of quality of data, including relevant articles. Short summary is preferred.
+    default: null
+    required: true
+MapProjection:
+    description: >
+        Applies to gridded data. Useful for application data tools, such as ArcGIS
+    default: null
+    required: false
+ValidationData:
+    description: >
+        Description of or reference on how the data were validated
+    default: null
+    required: false
+history:
+    description: >
+        An audit trail for modifications to the original data. Well-behaved generic netCDF filters automatically append their names and the parameters with which they were invoked to the global history attribute of an input netCDF file. We recommend that each line begins with a timestamp indicating the date and time of day that the program was executed.
+    default: null
+    required: false
+references:
+    description: >
+      Published or Web-based references that describe the data or methods used to produce the data, e.g.,
+      Algorithm Theoretical Basis Document
+      (ATBD) for the algorithm
+    default: null
+    required: false
+ContactPersonName:
+    description: >
+        Name of the responsible person
+    default: null
+    required: false
+ContactPersonRole:
+    description: >
+        Role of the responsible person
+    default: null
+    required: false
+ContactPersonEmail:
+    description: >
+        electronicMailAddress of the responsible person
+    default: null
+    required: false
+ContactPersonAddress:
+    description: >
+        Location of the responsible person or organization
+    default: null
+    required: false
+RelatedURL:
+    description: >
+        Information about online sources related to the data
+    default: null
+    required: false
+#also an attribute convention for data discovery (ACDD) global metadata
+title:
+    description: >
+      A succinct description of the data set
+      (similar to or same as LongName)
+    default: null
+    required: false
+institution:
+    description: >
+      Where the data were produced
+    default: null
+    required: false
+ProjectAbstract:
+    description: >
+      A brief summary of the project from which the data originated
+    default: null
+    required: false
+DataSetLanguage:
+    description: >
+      Language used within the data set, LanguageCode=ISO 639
+      default=English
+    default: null
+    required: false
+ProductParameters:
+    description: >
+      Keywords describing the data set
+    default: null
+    required: false
+# GES DISC optional attribute (singular keyword vs plural keywords for data discovery)
+Keyword:
+    description: >
+      Commonly-use word(s) or phrase(s), e.g., Deep Blue Algorithm
+    default: null
+    required: false
+# Attribute convention for data discovery (ACDD) global metadata
+Keywords:
+    description: >
+      A comma-separated list of key words and/or phrases. Keywords may be common words or phrases, terms from a controlled vocabulary (GCMD is often used), or URIs for terms from a controlled vocabulary (see also "keywords_vocabulary" attribute).
+    default: null
+    required: false
+ProcessingCenter:
+    description: >
+      Organization from which the data set can be obtained
+    default: null
+    required: false
+InputDataProducts:
+    description: >
+      Input data to the product of interest
+    default: null
+    required: false
+InputDataProductVersion:
+    description: >
+      Input data version
+    default: null
+    required: false
+DataProgress:
+    description: >
+      Status of data set
+    default: null
+    required: false
+TemporalRange:
+    description: >
+      Time period covered by the data set
+    default: null
+    required: false
+SpatialCoverage:
+    description: >
+      Geographic domain of the data set
+    default: null
+    required: false
+DataResolution:
+    description: >
+      Information about spatial resolution
+    default: null
+    required: false
+
+
+
+# Granule Level global metadata
+GranuleID:
+  description: >
+    name of the data granule (most commonly filename for single-file granules)
+  default: null
+  required: true
+RangeBeginningDate:
+    description: >
+        start date of the data in the file (format YYYY-MM-DD)
+    default: null
+    required: true
+RangeBeginningTime:
+    description: >
+        start time UTC of the data (format hh:mm:ss.ssssss)
+    default: null
+    required: true
+RangeEndingDate:
+    description: >
+        end date of the data in the file (format YYYY-MM-DD)
+    default: null
+    required: true
+RangeEndingTime:
+    description: >
+        end time UTC of the data (format hh:mm:ss.ssssss)
+    default: null
+    required: true
+ProductionDateTime:
+  description: >
+    the date and time that the file is generated (format YYYY-MM-DDT hh:mm:ss.ssssssZ, e.g., 2013-06-04T12:43:17.896000Z)
+  default: null
+  required: true
+ObservationArea:
+    description: >
+      Spatial coverage of the data (global or name of a geographic region)
+    default: null
+    required: false
+InputOriginalFile:
+    description: >
+      Input data files used to generate the file
+    default: null
+    required: false
+ProductGenerationAlgorithm:
+    description: >
+      The algorithm software used to produce the granule
+    default: null
+    required: false
+ProductGenerationAlgorithmVersion:
+    description: >
+      The version of algorithm that generates the product
+    default: null
+    required: false
+OriginalFileVersion:
+    description: >
+      Original File version
+    default: null
+    required: false
+OriginalFileProcessingCenter:
+    description: >
+      The data center or project where the product is generated
+    default: null
+    required: false
+SpatialCompletenessDefinition:
+    description: >
+      Definition of a measure of data quality: i.e. the ratio of grid elements containing valid values to total number of grid elements
+    default: null
+    required: false
+SpatialCompletenessRatio:
+    description: >
+      The data quality information: value for the previous metadata
+    default: null
+    required: false
+
+# Attribute Convention for Data Discovery (ACDD) global metadata

--- a/sammi/data/default_variable_acdd_attrs_schema.yaml
+++ b/sammi/data/default_variable_acdd_attrs_schema.yaml
@@ -1,0 +1,31 @@
+# https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3#Global_Attributes
+
+long_name:
+    description: >
+        A long descriptive name for the variable (not necessarily from a controlled vocabulary).
+        This attribute is recommended by the NetCDF Users Guide, the COARDS convention, and the
+        CF convention.
+    default: null
+    required: false
+standard_name:
+    description: >
+        A long descriptive name for the variable taken from a controlled vocabulary of variable
+        names. We recommend using the CF convention and the variable names from the CF standard
+        name table. This attribute is recommended by the CF convention.
+    default: null
+    required: false
+units:
+    description: >
+        The units of the variable's data values. This attribute value should be a valid udunits
+        string. The "units" attribute is recommended by the NetCDF Users Guide, the COARDS
+        convention, and the CF convention.
+    default: null
+    required: false
+coverage_content_type:
+    description: >
+        An ISO 19115-1 code to indicate the source of the data (image, thematicClassification,
+        physicalMeasurement, auxiliaryInformation, qualityInformation, referenceInformation,
+        modelResult, or coordinate).
+    default: null
+    required: false
+

--- a/sammi/data/default_variable_cf_attrs_schema.yaml
+++ b/sammi/data/default_variable_cf_attrs_schema.yaml
@@ -24,7 +24,7 @@ units:
     Examples for unitless variables:
     fractions or ratio => "1" or "percent"
     number of pixels in a grid cell => "count"
-    index (or flag) variable => may exclude units
+    index (or flag) variable => Use a blank character
   default: null
   required: true
 valid_range:

--- a/sammi/data/default_variable_cf_attrs_schema.yaml
+++ b/sammi/data/default_variable_cf_attrs_schema.yaml
@@ -1,4 +1,4 @@
-# Schema is based on the CF# Schema is based on CF conventions as defined by NASA GES DISC Archive's
+# Schema is based on the CF Schema is based on CF conventions as defined by NASA GES DISC Archive's
 ## Data and Metadata Recommendations to Data providers document:
 ## https://docserver.gesdisc.eosdis.nasa.gov/public/project/DataPub/GES_DISC_metadata_and_data_formats.pdf
 

--- a/sammi/data/default_variable_cf_attrs_schema.yaml
+++ b/sammi/data/default_variable_cf_attrs_schema.yaml
@@ -1,0 +1,60 @@
+# Schema is based on the CF# Schema is based on CF conventions as defined by NASA GES DISC Archive's
+## Data and Metadata Recommendations to Data providers document:
+## https://docserver.gesdisc.eosdis.nasa.gov/public/project/DataPub/GES_DISC_metadata_and_data_formats.pdf
+
+long_name:
+  description: >
+    Parameter long name; recommend using underscore as delimiter; not recommend using dash and white space
+  default: null
+  required: true
+standard_name:
+  description: >
+    Parameter name recommended by CF-convention community (https://cfconventions.org/)
+  default: null
+  required: false
+_FillValue:
+  description: >
+    Fill value or missing value (format: number, e.g., float or double, integer). Not for coordinate variables.
+    For variables that contain two types of missing values, we recommend adding a flag variable to indicate the missing data type.
+  default: null
+  required: true
+units:
+  description: >
+    Must follow standards for coordinate (or dimension) variables, such as longitude, latitude, and time (Sec. 2.3.4).
+    Examples for unitless variables:
+    fractions or ratio => "1" or "percent"
+    number of pixels in a grid cell => "count"
+    index (or flag) variable => may exclude units
+  default: null
+  required: true
+valid_range:
+  description: >
+    Valid minimum and maximum values
+  default: null
+  required: false
+scale_factor:
+  description: >
+    Scaling factor (use for scaled variables)
+  default: null
+  required: false
+scale_offset:
+  description: >
+    Scaling offset (use for scaled variables)
+  default: null
+  required: false
+flag_values:
+  description: >
+    Values of data quality flag or any other flag index variable, e.g., flag_values = 1, 2, 3, 4
+  default: null
+  required: false
+flag_meanings:
+  description: >
+    Meanings of flag values, e.g., flag_meanings = no_confidence, marginal, good, very_good for flag_values = 1, 2, 3, 4, respectively
+  default: null
+  required: false
+comments:
+  description: >
+    Additional description or comments about a parameter
+  default: null
+  required: false
+

--- a/sammi/data/default_variable_cf_attrs_schema.yaml
+++ b/sammi/data/default_variable_cf_attrs_schema.yaml
@@ -1,60 +1,185 @@
-# Schema is based on the CF Schema is based on CF conventions as defined by NASA GES DISC Archive's
-## Data and Metadata Recommendations to Data providers document:
-## https://docserver.gesdisc.eosdis.nasa.gov/public/project/DataPub/GES_DISC_metadata_and_data_formats.pdf
+# https://cfconventions.org/Data/cf-conventions/cf-conventions-1.13/cf-conventions.html#attribute-appendix
 
-long_name:
-  description: >
-    Parameter long name; recommend using underscore as delimiter; not recommend using dash and white space
-  default: null
-  required: true
-standard_name:
-  description: >
-    Parameter name recommended by CF-convention community (https://cfconventions.org/)
-  default: null
-  required: false
+actual_range:
+    description: >
+        The smallest and the largest valid non-missing values occurring in the variable.
+    default: null
+    required: false
+add_offset:
+    description: >
+        If present for a variable, this number is to be added to the data after it is read by an
+        application. If both scale_factor and add_offset attributes are present, the data are first
+        scaled before the offset is added. In cases where there is a strong constraint on dataset
+        size, it is allowed to pack the coordinate variables (using add_offset and/or scale_factor),
+        but this is not recommended in general.
+    default: null
+    required: false
+ancillary_variables:
+    description: >
+        Identifies a variable that contains closely associated data, e.g., the measurement
+        uncertainties of instrument data.
+    default: null
+    required: false
+cell_measures:
+    description: >
+        Identifies variables that contain cell areas or volumes.
+    default: null
+    required: false
+cell_methods:
+    description: >
+        Records the method used to derive data that represents cell values.
+    default: null
+    required: false
+comment:
+    description: >
+        Miscellaneous information about the data or methods used to produce it.
+    default: null
+    required: false
+coordinate_interpolation:
+    description: >
+        Indicates that coordinates have been compressed by sampling and identifies the tie point
+        coordinate variables and their associated interpolation variables.
+    default: null
+    required: false
+coordinates:
+    description: >
+        Identifies auxiliary coordinate variables, label variables, and alternate coordinate variables.
+    default: null
+    required: false
 _FillValue:
-  description: >
-    Fill value or missing value (format: number, e.g., float or double, integer). Not for coordinate variables.
-    For variables that contain two types of missing values, we recommend adding a flag variable to indicate the missing data type.
-  default: null
-  required: true
-units:
-  description: >
-    Must follow standards for coordinate (or dimension) variables, such as longitude, latitude, and time (Sec. 2.3.4).
-    Examples for unitless variables:
-    fractions or ratio => "1" or "percent"
-    number of pixels in a grid cell => "count"
-    index (or flag) variable => Use a blank character
-  default: null
-  required: true
-valid_range:
-  description: >
-    Valid minimum and maximum values
-  default: null
-  required: false
-scale_factor:
-  description: >
-    Scaling factor (use for scaled variables)
-  default: null
-  required: false
-scale_offset:
-  description: >
-    Scaling offset (use for scaled variables)
-  default: null
-  required: false
-flag_values:
-  description: >
-    Values of data quality flag or any other flag index variable, e.g., flag_values = 1, 2, 3, 4
-  default: null
-  required: false
+    description: >
+        A value used to represent missing or undefined data. Allowed for auxiliary coordinate
+        variables but not allowed for coordinate variables.
+    default: null
+    required: false
+flag_masks:
+    description: >
+        Provides a list of bit fields expressing Boolean or enumerated flags.
+    default: null
+    required: false
 flag_meanings:
-  description: >
-    Meanings of flag values, e.g., flag_meanings = no_confidence, marginal, good, very_good for flag_values = 1, 2, 3, 4, respectively
-  default: null
-  required: false
-comments:
-  description: >
-    Additional description or comments about a parameter
-  default: null
-  required: false
-
+    description: >
+        Use in conjunction with flag_values to provide descriptive words or phrases for each flag
+        value. If multi-word phrases are used to describe the flag values, then the words within a
+        phrase should be connected with underscores.
+    default: null
+    required: false
+flag_values:
+    description: >
+        Provides a list of the flag values. Use in conjunction with flag_meanings.
+    default: null
+    required: false
+geometry:
+    description: >
+        Identifies a variable that defines geometry.
+    default: null
+    required: false
+grid_mapping:
+    description: >
+        Identifies a variable that defines a grid mapping.
+    default: null
+    required: false
+institution:
+    description: >
+        Where the original data was produced.
+    default: null
+    required: false
+location:
+    description: >
+        Specifies the location type within the mesh topology at which the variable is defined.
+    default: null
+    required: false
+location_index_set:
+    description: >
+        Specifies a variable that defines the subset of locations of a mesh topology at which the
+        variable is defined.
+    default: null
+    required: false
+long_name:
+    description: >
+        A descriptive name that indicates a variable's content. This name is not standardized.
+    default: null
+    required: false
+mesh:
+    description: >
+        Specifies a variable that defines a mesh topology.
+    default: null
+    required: false
+missing_value:
+    description: >
+        A value or values used to represent missing or undefined data. Allowed for auxiliary
+        coordinate variables but not allowed for coordinate variables.
+    default: null
+    required: false
+quantization:
+    description: >
+        Identifies a variable that defines a quantization algorithm and its provenance.
+    default: null
+    required: false
+quantization_nsb:
+    description: >
+        Specifies the number of significant bits retained in the IEEE mantissa of data quantized
+        with the BitRound algorithm. Use in conjunction with quantization.
+    default: null
+    required: false
+quantization_nsd:
+    description: >
+        Specifies the number of significant base-10 digits retained in the IEEE mantissa of data
+        quantized with base-10 quantization algorithms. Use in conjunction with quantization.
+    default: null
+    required: false
+references:
+    description: >
+        References that describe the data or methods used to produce it.
+    default: null
+    required: false
+scale_factor:
+    description: >
+        If present for a variable, the data are to be multiplied by this factor after the data are
+        read by an application. See also the add_offset attribute. In cases where there is a strong
+        constraint on dataset size, it is allowed to pack the coordinate variables (using add_offset
+        and/or scale_factor), but this is not recommended in general.
+    default: null
+    required: false
+source:
+    description: >
+        Method of production of the original data.
+    default: null
+    required: false
+standard_error_multiplier:
+    description: >
+        If a data variable with a standard_name modifier of standard_error has this attribute, it
+        indicates that the values are the stated multiple of one standard error.
+    default: null
+    required: false
+standard_name:
+    description: >
+        A standard name that references a description of a variable's content in the standard
+        name table.
+    default: null
+    required: false
+units:
+    description: >
+        Units of a variable's content.
+    default: null
+    required: false
+units_metadata:
+    description: >
+        Specifies the interpretation of a unit of measure appearing in the units attribute.
+    default: null
+    required: false
+valid_max:
+    description: >
+        Largest valid value of a variable.
+    default: null
+    required: false
+valid_min:
+    description: >
+        Smallest valid value of a variable.
+    default: null
+    required: false
+valid_range:
+    description: >
+        Smallest and largest valid values of a variable.
+    default: null
+    required: false

--- a/sammi/data/default_variable_gesdisc_attrs_schema.yaml
+++ b/sammi/data/default_variable_gesdisc_attrs_schema.yaml
@@ -1,0 +1,60 @@
+# Schema is based on the CF Schema is based on CF conventions as defined by NASA GES DISC Archive's
+## Data and Metadata Recommendations to Data providers document:
+## https://docserver.gesdisc.eosdis.nasa.gov/public/project/DataPub/GES_DISC_metadata_and_data_formats.pdf
+
+long_name:
+  description: >
+    Parameter long name; recommend using underscore as delimiter; not recommend using dash and white space
+  default: null
+  required: true
+standard_name:
+  description: >
+    Parameter name recommended by CF-convention community (https://cfconventions.org/)
+  default: null
+  required: false
+_FillValue:
+  description: >
+    Fill value or missing value (format: number, e.g., float or double, integer). Not for coordinate variables.
+    For variables that contain two types of missing values, we recommend adding a flag variable to indicate the missing data type.
+  default: null
+  required: true
+units:
+  description: >
+    Must follow standards for coordinate (or dimension) variables, such as longitude, latitude, and time (Sec. 2.3.4).
+    Examples for unitless variables:
+    fractions or ratio => "1" or "percent"
+    number of pixels in a grid cell => "count"
+    index (or flag) variable => Use a blank character
+  default: null
+  required: true
+valid_range:
+  description: >
+    Valid minimum and maximum values
+  default: null
+  required: false
+scale_factor:
+  description: >
+    Scaling factor (use for scaled variables)
+  default: null
+  required: false
+scale_offset:
+  description: >
+    Scaling offset (use for scaled variables)
+  default: null
+  required: false
+flag_values:
+  description: >
+    Values of data quality flag or any other flag index variable, e.g., flag_values = 1, 2, 3, 4
+  default: null
+  required: false
+flag_meanings:
+  description: >
+    Meanings of flag values, e.g., flag_meanings = no_confidence, marginal, good, very_good for flag_values = 1, 2, 3, 4, respectively
+  default: null
+  required: false
+comments:
+  description: >
+    Additional description or comments about a parameter
+  default: null
+  required: false
+


### PR DESCRIPTION
This adds schema for the CF (https://cfconventions.org/) metadata convention. This schema was developed for the TSIS-2 mission whose archive, GES DISC, recommends the CF convention. The fields in the schema are based on GES DISC's documentation of the CF convention: https://docserver.gesdisc.eosdis.nasa.gov/public/project/DataPub/GES_DISC_metadata_and_data_formats.pdf

More work will need to be done to expand this to all the fields available in the CF convention, but at this point, that is out of the scope of the work I have.

I'm not sure where the line is drawn between general conventions and archive specific requirements and I'm not familiar enough with the CF convention to know how much, if at all, the GES DISC's documentation of the CF convention deviates from it.